### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,5 +1,9 @@
 name: Build Status Swift
 
+permissions:
+  contents: read
+  actions: read
+
 # Workflow triggers
 on: 
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/clFaster/StatusSwift/security/code-scanning/1](https://github.com/clFaster/StatusSwift/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` to allow the workflow to access the repository's contents.
- `actions: read` to allow the workflow to interact with GitHub Actions artifacts (e.g., downloading or uploading artifacts).

The `permissions` block will be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
